### PR TITLE
Add planning overview page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+.env
+warehouse.db
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Lagerverwaltungssystem für Maschinenbauunternehmen
+
+Dieses Projekt stellt ein leichtgewichtiges Lagerverwaltungssystem (Warehouse Management System, WMS) für Maschinenbauunternehmen bereit. Es kombiniert ein webbasiertes Bedien-Interface mit einer REST-API und einer Schnittstelle für ein angebundenes ERP-System.
+
+## Funktionen
+
+- Verwaltung von Artikeln mit Stammdaten wie Artikelnummer, Beschreibung, Einheit und Meldebestand
+- Pflege von Lagerorten und Beständen pro Artikel/Lagerort
+- Erfassung von Wareneingängen, Warenausgängen und Bestandskorrekturen inklusive Historie
+- Verwaltung von Lieferanten und Bestellungen (inklusive Bestellpositionen)
+- Dashboard mit Kennzahlen, Bestandswarnungen und jüngsten Bewegungen
+- Planungsübersicht mit Bestellvorschlägen basierend auf Meldebeständen und offenen Bestellungen
+- REST-API zur Integration mit anderen Anwendungen
+- ERP-Schnittstelle zum Export des aktuellen Bestands und zum Import offener Bestellungen
+
+## Projektstruktur
+
+```
+app/
+  api/              # REST-API-Router und Endpunkte
+  templates/        # Jinja2 Templates für die Weboberfläche
+  static/           # Statische Assets wie CSS
+```
+
+## Installation & Start
+
+1. Virtuelle Umgebung erstellen und aktivieren (optional)
+2. Abhängigkeiten installieren:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Server starten:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+4. Weboberfläche im Browser unter `http://127.0.0.1:8000` öffnen.
+
+## Konfiguration der ERP-Schnittstelle
+
+Die Kommunikation mit einem externen ERP-System lässt sich über Umgebungsvariablen konfigurieren. Unterstützte Variablen:
+
+- `WMS_ERP_BASE_URL`: Basis-URL des ERP-Endpunkts (z. B. `https://erp.example.com/api`)
+- `WMS_ERP_API_KEY`: Optionaler API-Key zur Authentifizierung
+
+Werden keine Werte gesetzt, bleibt die ERP-Schnittstelle aktiv, sendet aber keine externen Requests und liefert aussagekräftige Hinweise zurück.
+
+## Tests & Qualitätssicherung
+
+Zur schnellen Syntax-Prüfung kann `python -m compileall app` ausgeführt werden. Für weiterführende Tests lassen sich auf Basis der REST-API eigene Testfälle ergänzen.
+
+## Datenbank
+
+Standardmäßig wird eine SQLite-Datenbank (`warehouse.db`) im Projektverzeichnis genutzt. Für produktive Setups kann die Verbindung über die Umgebungsvariable `DATABASE_URL` auf andere Datenbanken (z. B. PostgreSQL) umgestellt werden.
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+"""Anwendungsmodul für das Lagerverwaltungssystem."""
+
+from .main import create_app
+
+__all__ = ["create_app"]

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,15 @@
+"""API-Router für das Lagerverwaltungssystem."""
+
+from fastapi import APIRouter
+
+from . import erp, inventory, items, locations, purchase_orders, suppliers
+
+api_router = APIRouter()
+api_router.include_router(items.router, prefix="/items", tags=["Artikel"])
+api_router.include_router(locations.router, prefix="/locations", tags=["Lagerorte"])
+api_router.include_router(suppliers.router, prefix="/suppliers", tags=["Lieferanten"])
+api_router.include_router(inventory.router, prefix="/inventory", tags=["Bestände"])
+api_router.include_router(purchase_orders.router, prefix="/purchase-orders", tags=["Bestellungen"])
+api_router.include_router(erp.router, prefix="/erp", tags=["ERP"])
+
+__all__ = ["api_router"]

--- a/app/api/erp.py
+++ b/app/api/erp.py
@@ -1,0 +1,35 @@
+"""REST-Endpunkte für den ERP-Datenaustausch."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from .. import schemas
+from ..dependencies import get_db, get_erp_service
+from ..erp import ERPService
+
+router = APIRouter()
+
+
+@router.post("/export/inventory", response_model=schemas.ERPExportResponse)
+async def export_inventory(
+    db: Session = Depends(get_db), service: ERPService = Depends(get_erp_service)
+) -> schemas.ERPExportResponse:
+    return await service.push_inventory_snapshot(db)
+
+
+@router.post("/sync/purchase-orders", response_model=schemas.ERPImportResult)
+async def sync_purchase_orders(
+    db: Session = Depends(get_db), service: ERPService = Depends(get_erp_service)
+) -> schemas.ERPImportResult:
+    return await service.sync_purchase_orders(db)
+
+
+@router.post("/ingest/purchase-orders", response_model=schemas.ERPImportResult)
+def ingest_purchase_orders(
+    payload: list[schemas.ERPPurchaseOrder],
+    db: Session = Depends(get_db),
+    service: ERPService = Depends(get_erp_service),
+) -> schemas.ERPImportResult:
+    return service.import_purchase_orders(db, list(payload))

--- a/app/api/inventory.py
+++ b/app/api/inventory.py
@@ -1,0 +1,40 @@
+"""REST-Endpunkte rund um Lagerbestände."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..dependencies import get_db
+
+router = APIRouter()
+
+
+@router.get("/levels", response_model=list[schemas.StockLevelRead])
+def read_stock_levels(db: Session = Depends(get_db)) -> list[schemas.StockLevelRead]:
+    return [schemas.StockLevelRead.model_validate(level) for level in crud.list_stock_levels(db)]
+
+
+@router.get("/transactions", response_model=list[schemas.InventoryTransactionRead])
+def read_transactions(
+    limit: int = Query(20, ge=1, le=100), db: Session = Depends(get_db)
+) -> list[schemas.InventoryTransactionRead]:
+    transactions = crud.list_transactions(db, limit=limit)
+    return [schemas.InventoryTransactionRead.model_validate(tx) for tx in transactions]
+
+
+@router.post("/transactions", response_model=schemas.InventoryTransactionRead, status_code=status.HTTP_201_CREATED)
+def create_transaction(
+    transaction_in: schemas.InventoryTransactionCreate, db: Session = Depends(get_db)
+) -> schemas.InventoryTransactionRead:
+    try:
+        transaction = crud.register_inventory_transaction(db, transaction_in)
+    except crud.CRUDException as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return schemas.InventoryTransactionRead.model_validate(transaction)
+
+
+@router.get("/dashboard", response_model=schemas.DashboardMetrics)
+def read_dashboard(db: Session = Depends(get_db)) -> schemas.DashboardMetrics:
+    return crud.get_inventory_overview(db)

--- a/app/api/items.py
+++ b/app/api/items.py
@@ -1,0 +1,50 @@
+"""REST-Endpunkte für Artikel."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..dependencies import get_db
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[schemas.ItemRead])
+def read_items(db: Session = Depends(get_db)) -> list[schemas.ItemRead]:
+    return [schemas.ItemRead.model_validate(item) for item in crud.list_items(db)]
+
+
+@router.post("/", response_model=schemas.ItemRead, status_code=status.HTTP_201_CREATED)
+def create_item(item_in: schemas.ItemCreate, db: Session = Depends(get_db)) -> schemas.ItemRead:
+    try:
+        item = crud.create_item(db, item_in)
+    except crud.CRUDException as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return schemas.ItemRead.model_validate(item)
+
+
+@router.get("/{item_id}", response_model=schemas.ItemRead)
+def read_item(item_id: int, db: Session = Depends(get_db)) -> schemas.ItemRead:
+    item = crud.get_item(db, item_id)
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artikel nicht gefunden")
+    return schemas.ItemRead.model_validate(item)
+
+
+@router.put("/{item_id}", response_model=schemas.ItemRead)
+def update_item(item_id: int, item_in: schemas.ItemUpdate, db: Session = Depends(get_db)) -> schemas.ItemRead:
+    item = crud.get_item(db, item_id)
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artikel nicht gefunden")
+    item = crud.update_item(db, item, item_in)
+    return schemas.ItemRead.model_validate(item)
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_item(item_id: int, db: Session = Depends(get_db)) -> None:
+    item = crud.get_item(db, item_id)
+    if not item:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artikel nicht gefunden")
+    crud.delete_item(db, item)

--- a/app/api/locations.py
+++ b/app/api/locations.py
@@ -1,0 +1,27 @@
+"""REST-Endpunkte für Lagerorte."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..dependencies import get_db
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[schemas.StorageLocationRead])
+def read_locations(db: Session = Depends(get_db)) -> list[schemas.StorageLocationRead]:
+    return [schemas.StorageLocationRead.model_validate(location) for location in crud.list_locations(db)]
+
+
+@router.post("/", response_model=schemas.StorageLocationRead, status_code=status.HTTP_201_CREATED)
+def create_location(
+    location_in: schemas.StorageLocationCreate, db: Session = Depends(get_db)
+) -> schemas.StorageLocationRead:
+    try:
+        location = crud.create_location(db, location_in)
+    except crud.CRUDException as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return schemas.StorageLocationRead.model_validate(location)

--- a/app/api/purchase_orders.py
+++ b/app/api/purchase_orders.py
@@ -1,0 +1,70 @@
+"""REST-Endpunkte für Bestellungen."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..dependencies import get_db
+from ..models import PurchaseOrder, PurchaseOrderLine
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[schemas.PurchaseOrderRead])
+def read_purchase_orders(db: Session = Depends(get_db)) -> list[schemas.PurchaseOrderRead]:
+    orders = crud.list_purchase_orders(db)
+    return [schemas.PurchaseOrderRead.model_validate(order) for order in orders]
+
+
+@router.post("/", response_model=schemas.PurchaseOrderRead, status_code=status.HTTP_201_CREATED)
+def create_purchase_order(
+    order_in: schemas.PurchaseOrderCreate, db: Session = Depends(get_db)
+) -> schemas.PurchaseOrderRead:
+    try:
+        order = crud.create_purchase_order(db, order_in)
+    except crud.CRUDException as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return schemas.PurchaseOrderRead.model_validate(order)
+
+
+@router.put("/{order_id}", response_model=schemas.PurchaseOrderRead)
+def update_purchase_order(
+    order_id: int, order_in: schemas.PurchaseOrderUpdate, db: Session = Depends(get_db)
+) -> schemas.PurchaseOrderRead:
+    order = db.get(PurchaseOrder, order_id)
+    if not order:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bestellung nicht gefunden")
+    order = crud.update_purchase_order(db, order, order_in)
+    return schemas.PurchaseOrderRead.model_validate(order)
+
+
+@router.post("/{order_id}/lines", response_model=schemas.PurchaseOrderLineRead, status_code=status.HTTP_201_CREATED)
+def add_purchase_order_line(
+    order_id: int, line_in: schemas.PurchaseOrderLineCreate, db: Session = Depends(get_db)
+) -> schemas.PurchaseOrderLineRead:
+    order = db.get(PurchaseOrder, order_id)
+    if not order:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bestellung nicht gefunden")
+    try:
+        line = crud.add_purchase_order_line(db, order, line_in)
+    except crud.CRUDException as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return schemas.PurchaseOrderLineRead.model_validate(line)
+
+
+@router.post("/lines/{line_id}/received", response_model=schemas.PurchaseOrderLineRead)
+def set_line_received(
+    line_id: int,
+    payload: schemas.PurchaseOrderReceiveUpdate,
+    db: Session = Depends(get_db),
+) -> schemas.PurchaseOrderLineRead:
+    line = db.get(PurchaseOrderLine, line_id)
+    if not line:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bestellposition nicht gefunden")
+    try:
+        updated_line = crud.set_purchase_order_line_received(db, line, payload.received_quantity)
+    except crud.CRUDException as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return schemas.PurchaseOrderLineRead.model_validate(updated_line)

--- a/app/api/suppliers.py
+++ b/app/api/suppliers.py
@@ -1,0 +1,27 @@
+"""REST-Endpunkte für Lieferanten."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..dependencies import get_db
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[schemas.SupplierRead])
+def read_suppliers(db: Session = Depends(get_db)) -> list[schemas.SupplierRead]:
+    return [schemas.SupplierRead.model_validate(supplier) for supplier in crud.list_suppliers(db)]
+
+
+@router.post("/", response_model=schemas.SupplierRead, status_code=status.HTTP_201_CREATED)
+def create_supplier(
+    supplier_in: schemas.SupplierCreate, db: Session = Depends(get_db)
+) -> schemas.SupplierRead:
+    try:
+        supplier = crud.create_supplier(db, supplier_in)
+    except crud.CRUDException as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return schemas.SupplierRead.model_validate(supplier)

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,495 @@
+"""Geschäftslogik und Datenbankoperationen."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, selectinload
+
+from . import schemas
+from .models import (
+    InventoryTransaction,
+    Item,
+    PurchaseOrder,
+    PurchaseOrderLine,
+    PurchaseOrderStatus,
+    StockLevel,
+    StorageLocation,
+    Supplier,
+    TransactionType,
+)
+
+
+class CRUDException(RuntimeError):
+    """Basisausnahme für CRUD-Operationen."""
+
+
+def list_items(db: Session) -> list[Item]:
+    return db.query(Item).order_by(Item.name).all()
+
+
+def get_item(db: Session, item_id: int) -> Item | None:
+    return db.get(Item, item_id)
+
+
+def create_item(db: Session, item_in: schemas.ItemCreate) -> Item:
+    if db.query(Item).filter(Item.sku == item_in.sku).first():
+        raise CRUDException("Artikelnummer existiert bereits.")
+    item = Item(
+        sku=item_in.sku,
+        name=item_in.name,
+        description=item_in.description,
+        unit_of_measure=item_in.unit_of_measure,
+        reorder_level=item_in.reorder_level,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+def update_item(db: Session, item: Item, item_in: schemas.ItemUpdate) -> Item:
+    for field in ("name", "description", "unit_of_measure", "reorder_level"):
+        value = getattr(item_in, field)
+        if value is not None:
+            setattr(item, field, value)
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+def delete_item(db: Session, item: Item) -> None:
+    db.delete(item)
+    db.commit()
+
+
+def list_locations(db: Session) -> list[StorageLocation]:
+    return db.query(StorageLocation).order_by(StorageLocation.name).all()
+
+
+def create_location(db: Session, location_in: schemas.StorageLocationCreate) -> StorageLocation:
+    if db.query(StorageLocation).filter(StorageLocation.name == location_in.name).first():
+        raise CRUDException("Lagerort existiert bereits.")
+    location = StorageLocation(name=location_in.name, description=location_in.description)
+    db.add(location)
+    db.commit()
+    db.refresh(location)
+    return location
+
+
+def ensure_default_location(db: Session) -> StorageLocation:
+    location = db.query(StorageLocation).order_by(StorageLocation.id).first()
+    if location:
+        return location
+    location = StorageLocation(name="Hauptlager", description="Automatisch erzeugter Standardlagerort")
+    db.add(location)
+    db.commit()
+    db.refresh(location)
+    return location
+
+
+def list_suppliers(db: Session) -> list[Supplier]:
+    return db.query(Supplier).order_by(Supplier.name).all()
+
+
+def create_supplier(db: Session, supplier_in: schemas.SupplierCreate) -> Supplier:
+    if db.query(Supplier).filter(Supplier.name == supplier_in.name).first():
+        raise CRUDException("Lieferant existiert bereits.")
+    supplier = Supplier(
+        name=supplier_in.name,
+        contact_email=supplier_in.contact_email,
+        contact_phone=supplier_in.contact_phone,
+        notes=supplier_in.notes,
+    )
+    db.add(supplier)
+    db.commit()
+    db.refresh(supplier)
+    return supplier
+
+
+def get_supplier_by_name(db: Session, name: str) -> Supplier | None:
+    return db.query(Supplier).filter(func.lower(Supplier.name) == func.lower(name)).first()
+
+
+def list_stock_levels(db: Session) -> list[StockLevel]:
+    return (
+        db.query(StockLevel)
+        .options(selectinload(StockLevel.item), selectinload(StockLevel.location))
+        .order_by(StockLevel.id)
+        .all()
+    )
+
+
+def get_stock_level(db: Session, item_id: int, location_id: int) -> StockLevel | None:
+    return (
+        db.query(StockLevel)
+        .filter(StockLevel.item_id == item_id, StockLevel.location_id == location_id)
+        .first()
+    )
+
+
+def register_inventory_transaction(
+    db: Session, transaction_in: schemas.InventoryTransactionCreate
+) -> InventoryTransaction:
+    item = db.get(Item, transaction_in.item_id)
+    location = db.get(StorageLocation, transaction_in.location_id)
+    if not item or not location:
+        raise CRUDException("Artikel oder Lagerort wurde nicht gefunden.")
+
+    if transaction_in.quantity == 0:
+        raise CRUDException("Die Bewegungsmenge darf nicht 0 sein.")
+
+    stock_level = get_stock_level(db, item.id, location.id)
+    if not stock_level:
+        stock_level = StockLevel(item=item, location=location, quantity=0)
+        db.add(stock_level)
+        db.flush()
+
+    quantity_delta = float(transaction_in.quantity)
+
+    if transaction_in.transaction_type == TransactionType.RECEIPT:
+        if quantity_delta <= 0:
+            raise CRUDException("Wareneingang benötigt eine positive Menge.")
+        stock_level.quantity += quantity_delta
+    elif transaction_in.transaction_type == TransactionType.SHIPMENT:
+        if quantity_delta <= 0:
+            raise CRUDException("Warenausgang benötigt eine positive Menge.")
+        if stock_level.quantity - quantity_delta < 0:
+            raise CRUDException("Der Bestand darf nicht negativ werden.")
+        stock_level.quantity -= quantity_delta
+    elif transaction_in.transaction_type == TransactionType.ADJUSTMENT:
+        # Bei Anpassungen wird die delta-Menge angewendet (kann positiv oder negativ sein).
+        new_quantity = stock_level.quantity + quantity_delta
+        if new_quantity < 0:
+            raise CRUDException("Der Bestand darf nicht negativ werden.")
+        stock_level.quantity = new_quantity
+    else:  # pragma: no cover - sollte durch Enum abgesichert sein
+        raise CRUDException("Unbekannter Bewegungstyp")
+
+    transaction = InventoryTransaction(
+        item=item,
+        location=location,
+        quantity=quantity_delta,
+        transaction_type=transaction_in.transaction_type,
+        reference=transaction_in.reference,
+        note=transaction_in.note,
+        created_at=datetime.utcnow(),
+    )
+    db.add(transaction)
+    db.commit()
+    db.refresh(transaction)
+    return transaction
+
+
+def list_transactions(db: Session, limit: int = 20) -> list[InventoryTransaction]:
+    return (
+        db.query(InventoryTransaction)
+        .options(selectinload(InventoryTransaction.item), selectinload(InventoryTransaction.location))
+        .order_by(InventoryTransaction.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def get_inventory_overview(db: Session) -> schemas.DashboardMetrics:
+    total_items = db.query(func.count(Item.id)).scalar() or 0
+    total_quantity = db.query(func.coalesce(func.sum(StockLevel.quantity), 0)).scalar() or 0
+    open_orders = (
+        db.query(func.count(PurchaseOrder.id))
+        .filter(PurchaseOrder.status != PurchaseOrderStatus.COMPLETED)
+        .scalar()
+        or 0
+    )
+
+    low_stock_rows = (
+        db.query(
+            Item,
+            func.coalesce(func.sum(StockLevel.quantity), 0).label("quantity"),
+        )
+        .outerjoin(StockLevel)
+        .group_by(Item.id)
+        .having(func.coalesce(func.sum(StockLevel.quantity), 0) <= Item.reorder_level)
+        .order_by(Item.name)
+        .all()
+    )
+    low_stock = [
+        {
+            "item_id": row.Item.id,
+            "sku": row.Item.sku,
+            "name": row.Item.name,
+            "quantity": float(row.quantity),
+            "reorder_level": row.Item.reorder_level,
+        }
+        for row in low_stock_rows
+    ]
+
+    recent_transactions = list_transactions(db, limit=10)
+
+    return schemas.DashboardMetrics(
+        total_items=total_items,
+        total_quantity=float(total_quantity),
+        open_orders=open_orders,
+        low_stock=low_stock,
+        recent_transactions=[schemas.InventoryTransactionRead.model_validate(tx) for tx in recent_transactions],
+    )
+
+
+def get_planning_overview(db: Session) -> list[schemas.PlanningSuggestion]:
+    """Berechnet Dispositionsempfehlungen pro Artikel."""
+
+    stock_subquery = (
+        db.query(
+            StockLevel.item_id.label("item_id"),
+            func.coalesce(func.sum(StockLevel.quantity), 0).label("on_hand"),
+        )
+        .group_by(StockLevel.item_id)
+        .subquery()
+    )
+
+    order_subquery = (
+        db.query(
+            PurchaseOrderLine.item_id.label("item_id"),
+            func.coalesce(
+                func.sum(PurchaseOrderLine.ordered_quantity - PurchaseOrderLine.received_quantity),
+                0,
+            ).label("on_order"),
+        )
+        .join(PurchaseOrder, PurchaseOrderLine.purchase_order_id == PurchaseOrder.id)
+        .filter(PurchaseOrderLine.item_id.isnot(None))
+        .filter(
+            PurchaseOrder.status.notin_(
+                [PurchaseOrderStatus.CANCELLED, PurchaseOrderStatus.COMPLETED]
+            )
+        )
+        .group_by(PurchaseOrderLine.item_id)
+        .subquery()
+    )
+
+    rows = (
+        db.query(
+            Item,
+            func.coalesce(stock_subquery.c.on_hand, 0).label("on_hand"),
+            func.coalesce(order_subquery.c.on_order, 0).label("on_order"),
+        )
+        .outerjoin(stock_subquery, stock_subquery.c.item_id == Item.id)
+        .outerjoin(order_subquery, order_subquery.c.item_id == Item.id)
+        .order_by(Item.name)
+        .all()
+    )
+
+    suggestions: list[schemas.PlanningSuggestion] = []
+    for row in rows:
+        item = row.Item
+        on_hand = float(row.on_hand or 0)
+        on_order = float(row.on_order or 0)
+        if on_order < 0:
+            on_order = 0.0
+        reorder_level = int(item.reorder_level or 0)
+        coverage_gap = float(reorder_level - (on_hand + on_order))
+        shortfall = coverage_gap if coverage_gap > 0 else 0.0
+        suggested_order = shortfall
+        suggestions.append(
+            schemas.PlanningSuggestion(
+                item_id=item.id,
+                sku=item.sku,
+                name=item.name,
+                reorder_level=reorder_level,
+                on_hand=on_hand,
+                on_order=on_order,
+                coverage_gap=coverage_gap,
+                shortfall=shortfall,
+                suggested_order=suggested_order,
+                needs_reorder=suggested_order > 0,
+            )
+        )
+
+    return suggestions
+
+
+def create_purchase_order(db: Session, order_in: schemas.PurchaseOrderCreate) -> PurchaseOrder:
+    if db.query(PurchaseOrder).filter(PurchaseOrder.order_number == order_in.order_number).first():
+        raise CRUDException("Bestellnummer existiert bereits.")
+    purchase_order = PurchaseOrder(
+        order_number=order_in.order_number,
+        supplier_id=order_in.supplier_id,
+        status=order_in.status,
+        expected_date=order_in.expected_date,
+        notes=order_in.notes,
+    )
+    if order_in.lines:
+        for line_in in order_in.lines:
+            line = _build_purchase_order_line(db, line_in)
+            purchase_order.lines.append(line)
+    db.add(purchase_order)
+    db.commit()
+    db.refresh(purchase_order)
+    return purchase_order
+
+
+def update_purchase_order(
+    db: Session, purchase_order: PurchaseOrder, order_in: schemas.PurchaseOrderUpdate
+) -> PurchaseOrder:
+    for field in ("supplier_id", "status", "expected_date", "notes"):
+        value = getattr(order_in, field)
+        if value is not None:
+            setattr(purchase_order, field, value)
+    db.add(purchase_order)
+    db.commit()
+    db.refresh(purchase_order)
+    return purchase_order
+
+
+def add_purchase_order_line(
+    db: Session, purchase_order: PurchaseOrder, line_in: schemas.PurchaseOrderLineCreate
+) -> PurchaseOrderLine:
+    line = _build_purchase_order_line(db, line_in)
+    purchase_order.lines.append(line)
+    db.add(purchase_order)
+    db.commit()
+    db.refresh(line)
+    return line
+
+
+def list_purchase_orders(db: Session) -> list[PurchaseOrder]:
+    return (
+        db.query(PurchaseOrder)
+        .options(
+            selectinload(PurchaseOrder.supplier),
+            selectinload(PurchaseOrder.lines).selectinload(PurchaseOrderLine.item),
+        )
+        .order_by(PurchaseOrder.created_at.desc())
+        .all()
+    )
+
+
+def set_purchase_order_line_received(
+    db: Session, line: PurchaseOrderLine, received_quantity: float
+) -> PurchaseOrderLine:
+    if received_quantity < 0:
+        raise CRUDException("Gelieferte Menge darf nicht negativ sein.")
+    line.received_quantity = received_quantity
+    db.add(line)
+    db.commit()
+    db.refresh(line)
+    return line
+
+
+def get_purchase_order_by_number(db: Session, order_number: str) -> PurchaseOrder | None:
+    return db.query(PurchaseOrder).filter(PurchaseOrder.order_number == order_number).first()
+
+
+def get_purchase_order_line(db: Session, line_id: int) -> PurchaseOrderLine | None:
+    return db.get(PurchaseOrderLine, line_id)
+
+
+def _build_purchase_order_line(
+    db: Session, line_in: schemas.PurchaseOrderLineCreate
+) -> PurchaseOrderLine:
+    item = None
+    if line_in.item_id is not None:
+        item = db.get(Item, line_in.item_id)
+        if not item:
+            raise CRUDException("Artikel für Bestellposition nicht gefunden.")
+    return PurchaseOrderLine(
+        item=item,
+        description=line_in.description,
+        ordered_quantity=line_in.ordered_quantity,
+        unit_price=line_in.unit_price,
+    )
+
+
+def get_or_create_item_by_sku(db: Session, sku: str, defaults: dict[str, Any] | None = None) -> Item:
+    item = db.query(Item).filter(Item.sku == sku).first()
+    if item:
+        return item
+    defaults = defaults or {}
+    item = Item(
+        sku=sku,
+        name=defaults.get("name", sku),
+        description=defaults.get("description"),
+        unit_of_measure=defaults.get("unit_of_measure", "Stk"),
+        reorder_level=int(defaults.get("reorder_level", 0)),
+    )
+    db.add(item)
+    db.flush()
+    return item
+
+
+def get_or_create_supplier_by_name(db: Session, name: str) -> Supplier:
+    supplier = get_supplier_by_name(db, name)
+    if supplier:
+        return supplier
+    supplier = Supplier(name=name)
+    db.add(supplier)
+    db.flush()
+    return supplier
+
+
+def import_purchase_orders_from_payload(
+    db: Session, payload: Iterable[schemas.ERPPurchaseOrder]
+) -> schemas.ERPImportResult:
+    imported = 0
+    updated = 0
+    skipped = 0
+    details: list[str] = []
+
+    for order in payload:
+        supplier = get_or_create_supplier_by_name(db, order.supplier_name)
+        existing = get_purchase_order_by_number(db, order.order_number)
+
+        if existing is None:
+            purchase_order = PurchaseOrder(
+                order_number=order.order_number,
+                supplier=supplier,
+                status=order.status,
+                expected_date=order.expected_date,
+                notes=order.notes,
+            )
+            _replace_purchase_order_lines(db, purchase_order, order.lines)
+            db.add(purchase_order)
+            imported += 1
+        else:
+            existing.supplier = supplier
+            existing.status = order.status
+            existing.expected_date = order.expected_date
+            existing.notes = order.notes
+            _replace_purchase_order_lines(db, existing, order.lines)
+            updated += 1
+
+        try:
+            db.commit()
+        except IntegrityError as exc:  # pragma: no cover - Fehlerfall
+            db.rollback()
+            skipped += 1
+            details.append(f"Bestellung {order.order_number} konnte nicht gespeichert werden: {exc!s}")
+
+    return schemas.ERPImportResult(imported=imported, updated=updated, skipped=skipped, details=details)
+
+
+def _replace_purchase_order_lines(
+    db: Session, purchase_order: PurchaseOrder, lines: Iterable[schemas.ERPPurchaseOrderLine]
+) -> None:
+    purchase_order.lines.clear()
+    for line in lines:
+        item = get_or_create_item_by_sku(
+            db,
+            line.sku,
+            {
+                "name": line.name,
+                "description": line.description,
+            },
+        )
+        purchase_order.lines.append(
+            PurchaseOrderLine(
+                item=item,
+                description=line.description,
+                ordered_quantity=line.ordered_quantity,
+                unit_price=line.unit_price,
+            )
+        )
+    db.flush()

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,29 @@
+"""Datenbankkonfiguration und Session-Verwaltung."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./warehouse.db")
+
+_engine_kwargs: Dict[str, Any] = {}
+if DATABASE_URL.startswith("sqlite"):
+    _engine_kwargs["connect_args"] = {"check_same_thread": False}
+
+engine = create_engine(DATABASE_URL, **_engine_kwargs)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+Base = declarative_base()
+
+
+def init_db() -> None:
+    """Initialisiert die Datenbanktabellen."""
+    # Import erst innerhalb der Funktion, um zirkuläre Importe zu vermeiden.
+    from . import models  # noqa: WPS433  # pylint: disable=import-outside-toplevel
+
+    models  # nur zum Registrieren der Modelle benötigt
+    Base.metadata.create_all(bind=engine)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,41 @@
+"""Gemeinsame FastAPI-Dependencies."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from fastapi import Depends
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from sqlalchemy.orm import Session
+
+from .crud import ensure_default_location
+from .database import SessionLocal
+from .erp import ERPClient, ERPService
+
+
+class Settings(BaseSettings):
+    """Anwendungskonfiguration."""
+
+    erp_base_url: str | None = None
+    erp_api_key: str | None = None
+
+    model_config = SettingsConfigDict(env_prefix="WMS_", extra="ignore")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        ensure_default_location(db)
+        yield db
+    finally:
+        db.close()
+
+
+def get_erp_service(settings: Settings = Depends(get_settings)) -> ERPService:
+    client = ERPClient(base_url=settings.erp_base_url, api_key=settings.erp_api_key)
+    return ERPService(client)

--- a/app/erp.py
+++ b/app/erp.py
@@ -1,0 +1,128 @@
+"""ERP-Integration für den Datenaustausch."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from . import crud, schemas
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ERPClient:
+    """Asynchrone Kommunikation mit einem ERP-System."""
+
+    def __init__(self, base_url: str | None, api_key: str | None = None, timeout: float = 10.0) -> None:
+        self.base_url = base_url.rstrip("/") if base_url else None
+        self.api_key = api_key
+        self.timeout = timeout
+
+    async def push_inventory_snapshot(self, snapshot: schemas.InventorySnapshot) -> schemas.ERPExportResponse:
+        if not self.base_url:
+            return schemas.ERPExportResponse(
+                status="disabled",
+                transmitted=0,
+                message="ERP-Basis-URL ist nicht konfiguriert.",
+            )
+        try:
+            async with httpx.AsyncClient(
+                base_url=self.base_url,
+                timeout=self.timeout,
+                headers=self._build_headers(),
+            ) as client:
+                response = await client.post("/inventory/sync", json=snapshot.model_dump())
+                response.raise_for_status()
+                data = response.json()
+        except httpx.HTTPError as exc:  # pragma: no cover - Netzwerkausnahme
+            LOGGER.warning("Fehler beim Senden an das ERP: %s", exc)
+            return schemas.ERPExportResponse(status="error", transmitted=0, message=str(exc))
+
+        transmitted = int(data.get("transmitted", len(snapshot.entries))) if isinstance(data, dict) else len(snapshot.entries)
+        status = data.get("status", "ok") if isinstance(data, dict) else "ok"
+        message = data.get("message") if isinstance(data, dict) else None
+        return schemas.ERPExportResponse(status=status, transmitted=transmitted, message=message)
+
+    async def fetch_purchase_orders(self) -> list[dict[str, Any]]:
+        if not self.base_url:
+            return []
+        try:
+            async with httpx.AsyncClient(
+                base_url=self.base_url,
+                timeout=self.timeout,
+                headers=self._build_headers(),
+            ) as client:
+                response = await client.get("/purchase-orders/open")
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.HTTPError as exc:  # pragma: no cover - Netzwerkausnahme
+            LOGGER.warning("Fehler beim Abrufen aus dem ERP: %s", exc)
+            return []
+
+        if isinstance(payload, dict):
+            orders = payload.get("orders", [])
+            if isinstance(orders, list):
+                return orders
+            LOGGER.warning("Ungültige ERP-Antwortstruktur: %s", payload)
+            return []
+        if isinstance(payload, list):
+            return payload
+        LOGGER.warning("Unbekannter ERP-Antworttyp: %s", type(payload))
+        return []
+
+    def _build_headers(self) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+
+class ERPService:
+    """Geschäftslogik rund um den ERP-Datenaustausch."""
+
+    def __init__(self, client: ERPClient) -> None:
+        self.client = client
+
+    def build_inventory_snapshot(self, db) -> schemas.InventorySnapshot:
+        entries: list[schemas.InventorySnapshotEntry] = []
+        for level in crud.list_stock_levels(db):
+            entries.append(
+                schemas.InventorySnapshotEntry(
+                    sku=level.item.sku,
+                    item_name=level.item.name,
+                    location=level.location.name,
+                    quantity=float(level.quantity),
+                    unit_of_measure=level.item.unit_of_measure,
+                )
+            )
+        return schemas.InventorySnapshot(
+            generated_at=datetime.utcnow(),
+            warehouse="Maschinenbau-Zentrallager",
+            entries=entries,
+        )
+
+    async def push_inventory_snapshot(self, db) -> schemas.ERPExportResponse:
+        snapshot = self.build_inventory_snapshot(db)
+        return await self.client.push_inventory_snapshot(snapshot)
+
+    async def fetch_purchase_orders(self) -> list[schemas.ERPPurchaseOrder]:
+        raw_orders = await self.client.fetch_purchase_orders()
+        orders: list[schemas.ERPPurchaseOrder] = []
+        for raw_order in raw_orders:
+            try:
+                orders.append(schemas.ERPPurchaseOrder.model_validate(raw_order))
+            except Exception as exc:  # pragma: no cover - Validierungsfehler
+                LOGGER.warning("Ungültiger ERP-Auftrag übersprungen: %s", exc)
+        return orders
+
+    def import_purchase_orders(self, db, orders: list[schemas.ERPPurchaseOrder]) -> schemas.ERPImportResult:
+        return crud.import_purchase_orders_from_payload(db, orders)
+
+    async def sync_purchase_orders(self, db) -> schemas.ERPImportResult:
+        orders = await self.fetch_purchase_orders()
+        if not orders:
+            return schemas.ERPImportResult(details=["Keine Bestellungen vom ERP erhalten."])
+        return self.import_purchase_orders(db, orders)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,36 @@
+"""Einstiegspunkt für die FastAPI-Anwendung."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+
+from .api import api_router
+from .database import init_db
+from .web import router as web_router
+
+
+def create_app() -> FastAPI:
+    """Erzeugt und konfiguriert die FastAPI-Anwendung."""
+
+    init_db()
+
+    app = FastAPI(title="Lagerverwaltung Maschinenbau", version="1.0.0")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.include_router(web_router)
+    app.include_router(api_router, prefix="/api")
+    app.mount("/static", StaticFiles(directory="static"), name="static")
+
+    return app
+
+
+app = create_app()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,180 @@
+"""SQLAlchemy-Modelle für das Lagerverwaltungssystem."""
+
+from __future__ import annotations
+
+import enum
+from datetime import date, datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    DateTime,
+    Enum,
+    Float,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+class TransactionType(str, enum.Enum):
+    """Mögliche Arten von Lagerbewegungen."""
+
+    RECEIPT = "receipt"
+    SHIPMENT = "shipment"
+    ADJUSTMENT = "adjustment"
+
+
+class PurchaseOrderStatus(str, enum.Enum):
+    """Status einer Bestellung."""
+
+    DRAFT = "draft"
+    RELEASED = "released"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class Item(Base):
+    """Artikelstammdaten."""
+
+    __tablename__ = "items"
+    __table_args__ = (UniqueConstraint("sku", name="uq_items_sku"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    sku: Mapped[str] = mapped_column(String(64), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text())
+    unit_of_measure: Mapped[str] = mapped_column(String(32), default="Stk", nullable=False)
+    reorder_level: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    stock_levels: Mapped[list["StockLevel"]] = relationship(
+        "StockLevel", back_populates="item", cascade="all, delete-orphan"
+    )
+    transactions: Mapped[list["InventoryTransaction"]] = relationship(
+        "InventoryTransaction", back_populates="item", cascade="all, delete-orphan"
+    )
+    purchase_order_lines: Mapped[list["PurchaseOrderLine"]] = relationship(
+        "PurchaseOrderLine", back_populates="item"
+    )
+
+
+class StorageLocation(Base):
+    """Lagerort innerhalb des Unternehmens."""
+
+    __tablename__ = "storage_locations"
+    __table_args__ = (UniqueConstraint("name", name="uq_storage_locations_name"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text())
+
+    stock_levels: Mapped[list["StockLevel"]] = relationship(
+        "StockLevel", back_populates="location", cascade="all, delete-orphan"
+    )
+    transactions: Mapped[list["InventoryTransaction"]] = relationship(
+        "InventoryTransaction", back_populates="location", cascade="all, delete-orphan"
+    )
+
+
+class Supplier(Base):
+    """Lieferant für Bestellungen."""
+
+    __tablename__ = "suppliers"
+    __table_args__ = (UniqueConstraint("name", name="uq_suppliers_name"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    contact_email: Mapped[str | None] = mapped_column(String(255))
+    contact_phone: Mapped[str | None] = mapped_column(String(64))
+    notes: Mapped[str | None] = mapped_column(Text())
+
+    purchase_orders: Mapped[list["PurchaseOrder"]] = relationship(
+        "PurchaseOrder", back_populates="supplier"
+    )
+
+
+class StockLevel(Base):
+    """Bestand eines Artikels an einem konkreten Lagerort."""
+
+    __tablename__ = "stock_levels"
+    __table_args__ = (
+        UniqueConstraint("item_id", "location_id", name="uq_stock_levels_item_location"),
+        CheckConstraint("quantity >= 0", name="ck_stock_levels_quantity_positive"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    item_id: Mapped[int] = mapped_column(ForeignKey("items.id", ondelete="CASCADE"), nullable=False)
+    location_id: Mapped[int] = mapped_column(
+        ForeignKey("storage_locations.id", ondelete="CASCADE"), nullable=False
+    )
+    quantity: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+
+    item: Mapped[Item] = relationship("Item", back_populates="stock_levels")
+    location: Mapped[StorageLocation] = relationship("StorageLocation", back_populates="stock_levels")
+
+
+class InventoryTransaction(Base):
+    """Historie einzelner Lagerbewegungen."""
+
+    __tablename__ = "inventory_transactions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    item_id: Mapped[int] = mapped_column(ForeignKey("items.id", ondelete="CASCADE"), nullable=False)
+    location_id: Mapped[int] = mapped_column(
+        ForeignKey("storage_locations.id", ondelete="CASCADE"), nullable=False
+    )
+    quantity: Mapped[float] = mapped_column(Float, nullable=False)
+    transaction_type: Mapped[TransactionType] = mapped_column(Enum(TransactionType), nullable=False)
+    reference: Mapped[str | None] = mapped_column(String(128))
+    note: Mapped[str | None] = mapped_column(Text())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    item: Mapped[Item] = relationship("Item", back_populates="transactions")
+    location: Mapped[StorageLocation] = relationship("StorageLocation", back_populates="transactions")
+
+
+class PurchaseOrder(Base):
+    """Bestellkopf für externe Beschaffung."""
+
+    __tablename__ = "purchase_orders"
+    __table_args__ = (UniqueConstraint("order_number", name="uq_purchase_orders_number"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    order_number: Mapped[str] = mapped_column(String(64), nullable=False)
+    supplier_id: Mapped[int | None] = mapped_column(ForeignKey("suppliers.id"))
+    status: Mapped[PurchaseOrderStatus] = mapped_column(
+        Enum(PurchaseOrderStatus), default=PurchaseOrderStatus.DRAFT, nullable=False
+    )
+    expected_date: Mapped[date | None] = mapped_column(Date)
+    notes: Mapped[str | None] = mapped_column(Text())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    supplier: Mapped[Supplier | None] = relationship("Supplier", back_populates="purchase_orders")
+    lines: Mapped[list["PurchaseOrderLine"]] = relationship(
+        "PurchaseOrderLine", back_populates="purchase_order", cascade="all, delete-orphan"
+    )
+
+
+class PurchaseOrderLine(Base):
+    """Position innerhalb einer Bestellung."""
+
+    __tablename__ = "purchase_order_lines"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    purchase_order_id: Mapped[int] = mapped_column(
+        ForeignKey("purchase_orders.id", ondelete="CASCADE"), nullable=False
+    )
+    item_id: Mapped[int] = mapped_column(ForeignKey("items.id", ondelete="SET NULL"))
+    description: Mapped[str | None] = mapped_column(Text())
+    ordered_quantity: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+    received_quantity: Mapped[float] = mapped_column(Numeric(12, 2), default=0, nullable=False)
+    unit_price: Mapped[float | None] = mapped_column(Float)
+
+    purchase_order: Mapped[PurchaseOrder] = relationship("PurchaseOrder", back_populates="lines")
+    item: Mapped[Item | None] = relationship("Item", back_populates="purchase_order_lines")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,215 @@
+"""Pydantic-Schemas für API und Formvalidierung."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .models import PurchaseOrderStatus, TransactionType
+
+
+class ItemBase(BaseModel):
+    sku: str = Field(..., max_length=64)
+    name: str = Field(..., max_length=255)
+    description: str | None = None
+    unit_of_measure: str = Field(default="Stk", max_length=32)
+    reorder_level: int = Field(default=0, ge=0)
+
+
+class ItemCreate(ItemBase):
+    pass
+
+
+class ItemUpdate(BaseModel):
+    name: str | None = Field(default=None, max_length=255)
+    description: str | None = None
+    unit_of_measure: str | None = Field(default=None, max_length=32)
+    reorder_level: int | None = Field(default=None, ge=0)
+
+
+class ItemRead(ItemBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class StorageLocationBase(BaseModel):
+    name: str = Field(..., max_length=255)
+    description: str | None = None
+
+
+class StorageLocationCreate(StorageLocationBase):
+    pass
+
+
+class StorageLocationRead(StorageLocationBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SupplierBase(BaseModel):
+    name: str = Field(..., max_length=255)
+    contact_email: str | None = Field(default=None, max_length=255)
+    contact_phone: str | None = Field(default=None, max_length=64)
+    notes: str | None = None
+
+
+class SupplierCreate(SupplierBase):
+    pass
+
+
+class SupplierRead(SupplierBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class StockLevelRead(BaseModel):
+    id: int
+    quantity: float
+    item: ItemRead
+    location: StorageLocationRead
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class InventoryTransactionBase(BaseModel):
+    item_id: int
+    location_id: int
+    quantity: float = Field(..., ne=0)
+    transaction_type: TransactionType
+    reference: str | None = Field(default=None, max_length=128)
+    note: str | None = None
+
+
+class InventoryTransactionCreate(InventoryTransactionBase):
+    pass
+
+
+class InventoryTransactionRead(InventoryTransactionBase):
+    id: int
+    created_at: datetime
+    item: ItemRead
+    location: StorageLocationRead
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PurchaseOrderLineBase(BaseModel):
+    item_id: int | None = None
+    description: str | None = None
+    ordered_quantity: float = Field(..., gt=0)
+    unit_price: float | None = Field(default=None, ge=0)
+
+
+class PurchaseOrderLineCreate(PurchaseOrderLineBase):
+    pass
+
+
+class PurchaseOrderLineRead(PurchaseOrderLineBase):
+    id: int
+    received_quantity: float
+    item: ItemRead | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PurchaseOrderReceiveUpdate(BaseModel):
+    received_quantity: float = Field(..., ge=0)
+
+
+class PurchaseOrderBase(BaseModel):
+    order_number: str = Field(..., max_length=64)
+    supplier_id: int | None = None
+    status: PurchaseOrderStatus = PurchaseOrderStatus.DRAFT
+    expected_date: date | None = None
+    notes: str | None = None
+
+
+class PurchaseOrderCreate(PurchaseOrderBase):
+    lines: list[PurchaseOrderLineCreate] | None = None
+
+
+class PurchaseOrderUpdate(BaseModel):
+    supplier_id: int | None = None
+    status: PurchaseOrderStatus | None = None
+    expected_date: date | None = None
+    notes: str | None = None
+
+
+class PurchaseOrderRead(PurchaseOrderBase):
+    id: int
+    created_at: datetime
+    supplier: SupplierRead | None = None
+    lines: list[PurchaseOrderLineRead] = []
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class InventorySnapshotEntry(BaseModel):
+    sku: str
+    item_name: str
+    location: str
+    quantity: float
+    unit_of_measure: str
+
+
+class InventorySnapshot(BaseModel):
+    generated_at: datetime
+    warehouse: str
+    entries: list[InventorySnapshotEntry]
+
+
+class ERPPurchaseOrderLine(BaseModel):
+    sku: str
+    name: str
+    ordered_quantity: float
+    unit_price: float | None = None
+    description: str | None = None
+
+
+class ERPPurchaseOrder(BaseModel):
+    order_number: str
+    supplier_name: str
+    expected_date: date | None = None
+    status: PurchaseOrderStatus = PurchaseOrderStatus.RELEASED
+    notes: str | None = None
+    lines: list[ERPPurchaseOrderLine]
+
+
+class ERPImportResult(BaseModel):
+    imported: int = 0
+    updated: int = 0
+    skipped: int = 0
+    details: list[str] = []
+
+
+class ERPExportResponse(BaseModel):
+    status: str
+    transmitted: int = 0
+    message: str | None = None
+
+
+class DashboardMetrics(BaseModel):
+    total_items: int
+    total_quantity: float
+    open_orders: int
+    low_stock: list[dict[str, float | str]]
+    recent_transactions: list[InventoryTransactionRead]
+
+
+class PlanningSuggestion(BaseModel):
+    """Planungsinformation für einen Artikel."""
+
+    item_id: int
+    sku: str
+    name: str
+    reorder_level: int
+    on_hand: float
+    on_order: float
+    coverage_gap: float
+    shortfall: float
+    suggested_order: float
+    needs_reorder: bool

--- a/app/web.py
+++ b/app/web.py
@@ -1,0 +1,417 @@
+"""Routen für die HTML-Weboberfläche."""
+
+from __future__ import annotations
+
+from datetime import date
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from . import crud, schemas
+from .dependencies import get_db, get_erp_service
+from .erp import ERPService
+from .models import PurchaseOrder, PurchaseOrderLine, PurchaseOrderStatus, TransactionType
+
+router = APIRouter(include_in_schema=False)
+templates = Jinja2Templates(directory="templates")
+
+
+def _redirect(url: str, **params: str) -> RedirectResponse:
+    if params:
+        url = f"{url}?{urlencode(params)}"
+    return RedirectResponse(url, status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.get("/", response_class=HTMLResponse)
+def dashboard(
+    request: Request,
+    message: str | None = None,
+    error: str | None = None,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    metrics = crud.get_inventory_overview(db)
+    context = {
+        "request": request,
+        "metrics": metrics,
+        "message": message,
+        "error": error,
+    }
+    return templates.TemplateResponse("dashboard.html", context)
+
+
+@router.get("/planning", response_class=HTMLResponse)
+def show_planning(
+    request: Request,
+    message: str | None = None,
+    error: str | None = None,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    suggestions = crud.get_planning_overview(db)
+    monitored = [entry for entry in suggestions if entry.reorder_level > 0]
+    needs_reorder = [entry for entry in monitored if entry.needs_reorder]
+
+    open_orders_data: list[dict[str, object]] = []
+    for order in crud.list_purchase_orders(db):
+        if order.status in {PurchaseOrderStatus.CANCELLED, PurchaseOrderStatus.COMPLETED}:
+            continue
+        remaining = 0.0
+        outstanding_lines = 0
+        for line in order.lines:
+            ordered = float(line.ordered_quantity or 0)
+            received = float(line.received_quantity or 0)
+            open_quantity = ordered - received
+            if open_quantity > 0:
+                outstanding_lines += 1
+                remaining += open_quantity
+        if outstanding_lines == 0 and remaining <= 0:
+            continue
+        open_orders_data.append(
+            {
+                "order": order,
+                "remaining": remaining,
+                "outstanding_lines": outstanding_lines,
+            }
+        )
+
+    open_orders_data.sort(
+        key=lambda entry: (
+            entry["order"].expected_date or date.max,
+            entry["order"].order_number,
+        )
+    )
+
+    summary = {
+        "total_items": len(monitored) if monitored else len(suggestions),
+        "needs_reorder": len(needs_reorder),
+        "recommended_quantity": sum(entry.suggested_order for entry in needs_reorder),
+        "open_orders": len(open_orders_data),
+    }
+
+    context = {
+        "request": request,
+        "suggestions": suggestions,
+        "summary": summary,
+        "open_orders": open_orders_data,
+        "message": message,
+        "error": error,
+    }
+    return templates.TemplateResponse("planning/overview.html", context)
+
+
+@router.get("/items", response_class=HTMLResponse)
+def show_items(
+    request: Request,
+    message: str | None = None,
+    error: str | None = None,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    items = crud.list_items(db)
+    context = {
+        "request": request,
+        "items": items,
+        "message": message,
+        "error": error,
+    }
+    return templates.TemplateResponse("items/list.html", context)
+
+
+@router.post("/items")
+async def create_item(
+    request: Request,
+    sku: str = Form(...),
+    name: str = Form(...),
+    description: str = Form(""),
+    unit_of_measure: str = Form("Stk"),
+    reorder_level: int = Form(0),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    item_in = schemas.ItemCreate(
+        sku=sku,
+        name=name,
+        description=description or None,
+        unit_of_measure=unit_of_measure,
+        reorder_level=reorder_level,
+    )
+    try:
+        crud.create_item(db, item_in)
+    except crud.CRUDException as exc:
+        context = {
+            "request": request,
+            "items": crud.list_items(db),
+            "error": str(exc),
+        }
+        return templates.TemplateResponse("items/list.html", context, status_code=status.HTTP_400_BAD_REQUEST)
+    return _redirect(router.url_path_for("show_items"), message="Artikel angelegt")
+
+
+@router.get("/locations", response_class=HTMLResponse)
+def show_locations(
+    request: Request,
+    message: str | None = None,
+    error: str | None = None,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    locations = crud.list_locations(db)
+    context = {
+        "request": request,
+        "locations": locations,
+        "message": message,
+        "error": error,
+    }
+    return templates.TemplateResponse("locations/list.html", context)
+
+
+@router.post("/locations")
+async def create_location(
+    request: Request,
+    name: str = Form(...),
+    description: str = Form(""),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    location_in = schemas.StorageLocationCreate(name=name, description=description or None)
+    try:
+        crud.create_location(db, location_in)
+    except crud.CRUDException as exc:
+        context = {
+            "request": request,
+            "locations": crud.list_locations(db),
+            "error": str(exc),
+        }
+        return templates.TemplateResponse("locations/list.html", context, status_code=status.HTTP_400_BAD_REQUEST)
+    return _redirect(router.url_path_for("show_locations"), message="Lagerort angelegt")
+
+
+@router.get("/suppliers", response_class=HTMLResponse)
+def show_suppliers(
+    request: Request,
+    message: str | None = None,
+    error: str | None = None,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    suppliers = crud.list_suppliers(db)
+    context = {
+        "request": request,
+        "suppliers": suppliers,
+        "message": message,
+        "error": error,
+    }
+    return templates.TemplateResponse("suppliers/list.html", context)
+
+
+@router.post("/suppliers")
+async def create_supplier(
+    request: Request,
+    name: str = Form(...),
+    contact_email: str = Form(""),
+    contact_phone: str = Form(""),
+    notes: str = Form(""),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    supplier_in = schemas.SupplierCreate(
+        name=name,
+        contact_email=contact_email or None,
+        contact_phone=contact_phone or None,
+        notes=notes or None,
+    )
+    try:
+        crud.create_supplier(db, supplier_in)
+    except crud.CRUDException as exc:
+        context = {
+            "request": request,
+            "suppliers": crud.list_suppliers(db),
+            "error": str(exc),
+        }
+        return templates.TemplateResponse("suppliers/list.html", context, status_code=status.HTTP_400_BAD_REQUEST)
+    return _redirect(router.url_path_for("show_suppliers"), message="Lieferant angelegt")
+
+
+@router.get("/inventory", response_class=HTMLResponse)
+def show_inventory(
+    request: Request,
+    message: str | None = None,
+    error: str | None = None,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    context = {
+        "request": request,
+        "stock_levels": crud.list_stock_levels(db),
+        "items": crud.list_items(db),
+        "locations": crud.list_locations(db),
+        "transactions": crud.list_transactions(db, limit=15),
+        "transaction_types": list(TransactionType),
+        "message": message,
+        "error": error,
+    }
+    return templates.TemplateResponse("inventory/list.html", context)
+
+
+@router.post("/inventory/movements")
+async def create_inventory_movement(
+    request: Request,
+    item_id: int = Form(...),
+    location_id: int = Form(...),
+    quantity: float = Form(...),
+    transaction_type: str = Form(...),
+    reference: str = Form(""),
+    note: str = Form(""),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    try:
+        movement = schemas.InventoryTransactionCreate(
+            item_id=item_id,
+            location_id=location_id,
+            quantity=quantity,
+            transaction_type=TransactionType(transaction_type),
+            reference=reference or None,
+            note=note or None,
+        )
+        crud.register_inventory_transaction(db, movement)
+    except (ValueError, crud.CRUDException) as exc:
+        context = {
+            "request": request,
+            "stock_levels": crud.list_stock_levels(db),
+            "items": crud.list_items(db),
+            "locations": crud.list_locations(db),
+            "transactions": crud.list_transactions(db, limit=15),
+            "transaction_types": list(TransactionType),
+            "error": str(exc),
+        }
+        return templates.TemplateResponse("inventory/list.html", context, status_code=status.HTTP_400_BAD_REQUEST)
+    return _redirect(router.url_path_for("show_inventory"), message="Bewegung erfasst")
+
+
+@router.get("/purchase-orders", response_class=HTMLResponse)
+def show_purchase_orders(
+    request: Request,
+    message: str | None = None,
+    error: str | None = None,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    context = {
+        "request": request,
+        "orders": crud.list_purchase_orders(db),
+        "suppliers": crud.list_suppliers(db),
+        "items": crud.list_items(db),
+        "status_values": list(PurchaseOrderStatus),
+        "message": message,
+        "error": error,
+    }
+    return templates.TemplateResponse("purchase_orders/list.html", context)
+
+
+@router.post("/purchase-orders")
+async def create_purchase_order(
+    request: Request,
+    order_number: str = Form(...),
+    supplier_id: str = Form(""),
+    status_value: str = Form(PurchaseOrderStatus.RELEASED.value),
+    expected_date: str = Form(""),
+    notes: str = Form(""),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    supplier_id_value = int(supplier_id) if supplier_id else None
+    expected = date.fromisoformat(expected_date) if expected_date else None
+    order_in = schemas.PurchaseOrderCreate(
+        order_number=order_number,
+        supplier_id=supplier_id_value,
+        status=PurchaseOrderStatus(status_value),
+        expected_date=expected,
+        notes=notes or None,
+    )
+    try:
+        crud.create_purchase_order(db, order_in)
+    except (ValueError, crud.CRUDException) as exc:
+        context = {
+            "request": request,
+            "orders": crud.list_purchase_orders(db),
+            "suppliers": crud.list_suppliers(db),
+            "items": crud.list_items(db),
+            "status_values": list(PurchaseOrderStatus),
+            "error": str(exc),
+        }
+        return templates.TemplateResponse("purchase_orders/list.html", context, status_code=status.HTTP_400_BAD_REQUEST)
+    return _redirect(router.url_path_for("show_purchase_orders"), message="Bestellung angelegt")
+
+
+@router.post("/purchase-orders/{order_id}/lines")
+async def add_purchase_order_line(
+    order_id: int,
+    request: Request,
+    item_id: str = Form(""),
+    description: str = Form(""),
+    ordered_quantity: float = Form(...),
+    unit_price: str = Form(""),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    order = db.get(PurchaseOrder, order_id)
+    if not order:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bestellung nicht gefunden")
+    item_id_value = int(item_id) if item_id else None
+    unit_price_value = float(unit_price) if unit_price else None
+    line_in = schemas.PurchaseOrderLineCreate(
+        item_id=item_id_value,
+        description=description or None,
+        ordered_quantity=ordered_quantity,
+        unit_price=unit_price_value,
+    )
+    try:
+        crud.add_purchase_order_line(db, order, line_in)
+    except crud.CRUDException as exc:
+        context = {
+            "request": request,
+            "orders": crud.list_purchase_orders(db),
+            "suppliers": crud.list_suppliers(db),
+            "items": crud.list_items(db),
+            "status_values": list(PurchaseOrderStatus),
+            "error": str(exc),
+        }
+        return templates.TemplateResponse("purchase_orders/list.html", context, status_code=status.HTTP_400_BAD_REQUEST)
+    return _redirect(router.url_path_for("show_purchase_orders"), message="Position hinzugefügt")
+
+
+@router.post("/purchase-orders/{order_id}/receive")
+async def receive_purchase_order(
+    order_id: int,
+    request: Request,
+    line_id: int = Form(...),
+    received_quantity: float = Form(...),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    line = db.get(PurchaseOrderLine, line_id)
+    if not line:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bestellposition nicht gefunden")
+    try:
+        crud.set_purchase_order_line_received(db, line, received_quantity)
+    except crud.CRUDException as exc:
+        context = {
+            "request": request,
+            "orders": crud.list_purchase_orders(db),
+            "suppliers": crud.list_suppliers(db),
+            "items": crud.list_items(db),
+            "status_values": list(PurchaseOrderStatus),
+            "error": str(exc),
+        }
+        return templates.TemplateResponse("purchase_orders/list.html", context, status_code=status.HTTP_400_BAD_REQUEST)
+    return _redirect(router.url_path_for("show_purchase_orders"), message="Wareneingang aktualisiert")
+
+
+@router.post("/erp/export")
+async def trigger_erp_export(
+    service: ERPService = Depends(get_erp_service),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    result = await service.push_inventory_snapshot(db)
+    return _redirect(router.url_path_for("dashboard"), message=f"ERP-Export: {result.status}")
+
+
+@router.post("/erp/sync")
+async def trigger_erp_sync(
+    service: ERPService = Depends(get_erp_service),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    result = await service.sync_purchase_orders(db)
+    message = f"Importiert: {result.imported}, Aktualisiert: {result.updated}, Übersprungen: {result.skipped}"
+    return _redirect(router.url_path_for("dashboard"), message=message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+sqlalchemy>=2.0.25
+jinja2>=3.1.3
+httpx>=0.27.0
+pydantic-settings>=2.2.1
+python-multipart>=0.0.7

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,248 @@
+:root {
+  --bg: #f5f7fa;
+  --primary: #1f4b99;
+  --secondary: #0f6b50;
+  --danger: #c0392b;
+  --text: #1a1a1a;
+  --border: #d0d7e2;
+  --card-bg: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Inter", "Segoe UI", sans-serif;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.site-header {
+  background: var(--primary);
+  color: #fff;
+  padding: 1rem 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.site-header nav a {
+  color: #fff;
+  margin-left: 1rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.site-header nav a:hover {
+  text-decoration: underline;
+}
+
+main {
+  padding: 2rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.site-footer {
+  text-align: center;
+  padding: 1rem 0 2rem;
+  color: #6b6b6b;
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin-bottom: 1.5rem;
+}
+
+.alert-success {
+  background: #e9f6ef;
+  border: 1px solid #b6decf;
+}
+
+.alert-error {
+  background: #fdecea;
+  border: 1px solid #f5c0b8;
+  color: var(--danger);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 6px rgba(15, 50, 90, 0.08);
+}
+
+.card h2, .card h3, .card h4 {
+  margin-top: 0;
+}
+
+.card .number {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.order-card {
+  margin-bottom: 2rem;
+}
+
+.actions {
+  margin-top: 2rem;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.action-buttons button {
+  background: var(--secondary);
+  border: none;
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.action-buttons button:hover {
+  opacity: 0.9;
+}
+
+section + section {
+  margin-top: 2rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+table thead {
+  background: #eef2f9;
+}
+
+table th,
+table td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+table tbody tr:hover {
+  background: #f6f9ff;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge-warning {
+  background: #fff1c2;
+  color: #8a4f0a;
+}
+
+.badge-ok {
+  background: #e3f6ed;
+  color: #1f6b4a;
+}
+
+table tbody tr.needs-reorder {
+  background: #fff7f0;
+}
+
+table tbody tr.needs-reorder:hover {
+  background: #ffe6d1;
+}
+
+.form-section {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #3a3a3a;
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  margin-top: 0.4rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  font: inherit;
+  background: #fff;
+}
+
+.form-grid textarea {
+  resize: vertical;
+}
+
+.form-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.form-actions button {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.form-actions button:hover {
+  opacity: 0.92;
+}
+
+.muted {
+  color: #6b6b6b;
+  margin-top: 0.5rem;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block title %}Lagerverwaltung{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', path='/css/style.css') }}" />
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>Lagerverwaltung Maschinenbau</h1>
+      <nav>
+        <a href="{{ url_for('dashboard') }}">Dashboard</a>
+        <a href="{{ url_for('show_planning') }}">Planung</a>
+        <a href="{{ url_for('show_items') }}">Artikel</a>
+        <a href="{{ url_for('show_inventory') }}">Bestände</a>
+        <a href="{{ url_for('show_purchase_orders') }}">Bestellungen</a>
+        <a href="{{ url_for('show_locations') }}">Lagerorte</a>
+        <a href="{{ url_for('show_suppliers') }}">Lieferanten</a>
+      </nav>
+    </header>
+    <main>
+      {% if message %}
+      <div class="alert alert-success">{{ message }}</div>
+      {% endif %}
+      {% if error %}
+      <div class="alert alert-error">{{ error }}</div>
+      {% endif %}
+      {% block content %}{% endblock %}
+    </main>
+    <footer class="site-footer">
+      <small>&copy; Maschinenbau WMS</small>
+    </footer>
+  </body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+{% block title %}Dashboard - Lagerverwaltung{% endblock %}
+{% block content %}
+<section class="cards">
+  <div class="card">
+    <h2>Artikel</h2>
+    <p class="number">{{ metrics.total_items }}</p>
+  </div>
+  <div class="card">
+    <h2>Gesamtbestand</h2>
+    <p class="number">{{ '%.2f'|format(metrics.total_quantity) }}</p>
+  </div>
+  <div class="card">
+    <h2>Offene Bestellungen</h2>
+    <p class="number">{{ metrics.open_orders }}</p>
+  </div>
+</section>
+
+<section>
+  <h2>Bestandswarnungen</h2>
+  {% if metrics.low_stock %}
+  <table>
+    <thead>
+      <tr>
+        <th>Artikelnummer</th>
+        <th>Bezeichnung</th>
+        <th>Bestand</th>
+        <th>Meldebestand</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for entry in metrics.low_stock %}
+      <tr>
+        <td>{{ entry.sku }}</td>
+        <td>{{ entry.name }}</td>
+        <td>{{ '%.2f'|format(entry.quantity) }}</td>
+        <td>{{ entry.reorder_level }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>Aktuell keine Artikel unter Meldebestand.</p>
+  {% endif %}
+</section>
+
+<section>
+  <h2>Letzte Bewegungen</h2>
+  {% if metrics.recent_transactions %}
+  <table>
+    <thead>
+      <tr>
+        <th>Zeitpunkt</th>
+        <th>Artikel</th>
+        <th>Lagerort</th>
+        <th>Menge</th>
+        <th>Typ</th>
+        <th>Referenz</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for tx in metrics.recent_transactions %}
+      <tr>
+        <td>{{ tx.created_at.strftime('%d.%m.%Y %H:%M') }}</td>
+        <td>{{ tx.item.name }}</td>
+        <td>{{ tx.location.name }}</td>
+        <td>{{ '%.2f'|format(tx.quantity) }}</td>
+        <td>{{ tx.transaction_type.value }}</td>
+        <td>{{ tx.reference or '-' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>Noch keine Bewegungen vorhanden.</p>
+  {% endif %}
+</section>
+
+<section class="actions">
+  <h2>ERP-Aktionen</h2>
+  <div class="action-buttons">
+    <form method="post" action="{{ url_for('trigger_erp_export') }}">
+      <button type="submit">Bestand an ERP senden</button>
+    </form>
+    <form method="post" action="{{ url_for('trigger_erp_sync') }}">
+      <button type="submit">Bestellungen vom ERP abrufen</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/templates/inventory/list.html
+++ b/templates/inventory/list.html
@@ -1,0 +1,108 @@
+{% extends "base.html" %}
+{% block title %}Bestände - Lagerverwaltung{% endblock %}
+{% block content %}
+<section>
+  <h2>Aktuelle Bestände</h2>
+  {% if stock_levels %}
+  <table>
+    <thead>
+      <tr>
+        <th>Artikel</th>
+        <th>Artikelnummer</th>
+        <th>Lagerort</th>
+        <th>Menge</th>
+        <th>Einheit</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for level in stock_levels %}
+      <tr>
+        <td>{{ level.item.name }}</td>
+        <td>{{ level.item.sku }}</td>
+        <td>{{ level.location.name }}</td>
+        <td>{{ '%.2f'|format(level.quantity) }}</td>
+        <td>{{ level.item.unit_of_measure }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>Noch keine Bestände erfasst.</p>
+  {% endif %}
+</section>
+
+<section class="form-section">
+  <h2>Lagerbewegung erfassen</h2>
+  <form method="post" action="{{ url_for('create_inventory_movement') }}" class="form-grid">
+    <label>Artikel
+      <select name="item_id" required>
+        <option value="" disabled selected>Bitte wählen</option>
+        {% for item in items %}
+        <option value="{{ item.id }}">{{ item.sku }} – {{ item.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Lagerort
+      <select name="location_id" required>
+        <option value="" disabled selected>Bitte wählen</option>
+        {% for location in locations %}
+        <option value="{{ location.id }}">{{ location.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Menge
+      <input type="number" name="quantity" step="0.01" required />
+    </label>
+    <label>Bewegungsart
+      <select name="transaction_type" required>
+        {% for transaction in transaction_types %}
+        <option value="{{ transaction.value }}">{{ transaction.value }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Referenz
+      <input type="text" name="reference" />
+    </label>
+    <label class="full-width">Bemerkung
+      <textarea name="note" rows="3"></textarea>
+    </label>
+    <div class="form-actions">
+      <button type="submit">Buchen</button>
+    </div>
+  </form>
+</section>
+
+<section>
+  <h2>Jüngste Bewegungen</h2>
+  {% if transactions %}
+  <table>
+    <thead>
+      <tr>
+        <th>Zeitpunkt</th>
+        <th>Artikel</th>
+        <th>Lagerort</th>
+        <th>Menge</th>
+        <th>Typ</th>
+        <th>Referenz</th>
+        <th>Notiz</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for tx in transactions %}
+      <tr>
+        <td>{{ tx.created_at.strftime('%d.%m.%Y %H:%M') }}</td>
+        <td>{{ tx.item.name }}</td>
+        <td>{{ tx.location.name }}</td>
+        <td>{{ '%.2f'|format(tx.quantity) }}</td>
+        <td>{{ tx.transaction_type.value }}</td>
+        <td>{{ tx.reference or '-' }}</td>
+        <td>{{ tx.note or '-' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>Noch keine Bewegungen vorhanden.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/templates/items/list.html
+++ b/templates/items/list.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+{% block title %}Artikel - Lagerverwaltung{% endblock %}
+{% block content %}
+<section>
+  <h2>Artikelübersicht</h2>
+  {% if items %}
+  <table>
+    <thead>
+      <tr>
+        <th>Artikelnummer</th>
+        <th>Bezeichnung</th>
+        <th>Einheit</th>
+        <th>Meldebestand</th>
+        <th>Beschreibung</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in items %}
+      <tr>
+        <td>{{ item.sku }}</td>
+        <td>{{ item.name }}</td>
+        <td>{{ item.unit_of_measure }}</td>
+        <td>{{ item.reorder_level }}</td>
+        <td>{{ item.description or '-' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>Noch keine Artikel vorhanden.</p>
+  {% endif %}
+</section>
+
+<section class="form-section">
+  <h2>Neuen Artikel anlegen</h2>
+  <form method="post" class="form-grid">
+    <label>Artikelnummer
+      <input type="text" name="sku" required />
+    </label>
+    <label>Bezeichnung
+      <input type="text" name="name" required />
+    </label>
+    <label>Einheit
+      <input type="text" name="unit_of_measure" value="Stk" />
+    </label>
+    <label>Meldebestand
+      <input type="number" name="reorder_level" min="0" value="0" />
+    </label>
+    <label class="full-width">Beschreibung
+      <textarea name="description" rows="3"></textarea>
+    </label>
+    <div class="form-actions">
+      <button type="submit">Speichern</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/templates/locations/list.html
+++ b/templates/locations/list.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Lagerorte - Lagerverwaltung{% endblock %}
+{% block content %}
+<section>
+  <h2>Lagerorte</h2>
+  {% if locations %}
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Beschreibung</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for location in locations %}
+      <tr>
+        <td>{{ location.name }}</td>
+        <td>{{ location.description or '-' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>Noch keine Lagerorte angelegt.</p>
+  {% endif %}
+</section>
+
+<section class="form-section">
+  <h2>Neuen Lagerort anlegen</h2>
+  <form method="post" class="form-grid">
+    <label>Name
+      <input type="text" name="name" required />
+    </label>
+    <label class="full-width">Beschreibung
+      <textarea name="description" rows="3"></textarea>
+    </label>
+    <div class="form-actions">
+      <button type="submit">Speichern</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/templates/planning/overview.html
+++ b/templates/planning/overview.html
@@ -1,0 +1,119 @@
+{% extends "base.html" %}
+{% block title %}Planung & Disposition{% endblock %}
+{% block content %}
+<h2>Bedarfsplanung</h2>
+<p>
+  Diese Übersicht unterstützt die Materialdisposition, indem aktuelle Lagerbestände mit offenen Bestellungen
+  und hinterlegten Meldebeständen abgeglichen werden.
+</p>
+
+<div class="cards">
+  <div class="card">
+    <h3>Überwachte Artikel</h3>
+    <p class="number">{{ summary.total_items }}</p>
+    <p>Artikel mit Bestandsbewertung</p>
+  </div>
+  <div class="card">
+    <h3>Bestellung empfohlen</h3>
+    <p class="number">{{ summary.needs_reorder }}</p>
+    <p>Artikel unter Meldebestand</p>
+  </div>
+  <div class="card">
+    <h3>Empfohlene Menge</h3>
+    <p class="number">{{ '%.1f' % summary.recommended_quantity }}</p>
+    <p>Gesamte Bestellvorschlagsmenge</p>
+  </div>
+  <div class="card">
+    <h3>Offene Bestellungen</h3>
+    <p class="number">{{ summary.open_orders }}</p>
+    <p>Laufende externe Bestellungen</p>
+  </div>
+</div>
+
+<section>
+  <h2>Dispositionsempfehlungen</h2>
+  <p>
+    In der Tabelle wird der aktuelle Bestand inklusive offener Bestellungen dem Meldebestand gegenübergestellt.
+    Für Artikel mit negativer Abdeckung wird eine Bestellmenge vorgeschlagen.
+  </p>
+  <div class="table-wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th>Artikel</th>
+          <th>Artikelnummer</th>
+          <th>Meldebestand</th>
+          <th>Verfügbar</th>
+          <th>In Bestellung</th>
+          <th>Fehlmenge</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% if suggestions %}
+          {% for suggestion in suggestions %}
+            <tr class="{% if suggestion.needs_reorder %}needs-reorder{% endif %}">
+              <td>{{ suggestion.name }}</td>
+              <td>{{ suggestion.sku }}</td>
+              <td>{{ suggestion.reorder_level }}</td>
+              <td>{{ '%.1f' % suggestion.on_hand }}</td>
+              <td>{{ '%.1f' % suggestion.on_order }}</td>
+              <td>{{ '%.1f' % suggestion.shortfall }}</td>
+              <td>
+                {% if suggestion.needs_reorder %}
+                  <span class="badge badge-warning">Bestellung: {{ '%.1f' % suggestion.suggested_order }}</span>
+                {% else %}
+                  {% if suggestion.coverage_gap < 0 %}
+                    <span class="badge badge-ok">Puffer: {{ '%.1f' % (-suggestion.coverage_gap) }}</span>
+                  {% else %}
+                    <span class="badge badge-ok">Bestand ausreichend</span>
+                  {% endif %}
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        {% else %}
+          <tr>
+            <td colspan="7">Es wurden noch keine Artikel angelegt.</td>
+          </tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section>
+  <h2>Offene Bestellungen</h2>
+  {% if open_orders %}
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Bestellnummer</th>
+            <th>Lieferant</th>
+            <th>Erwarteter Eingang</th>
+            <th>Status</th>
+            <th>Offene Positionen</th>
+            <th>Offene Menge</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for entry in open_orders %}
+            {% set order = entry.order %}
+            <tr>
+              <td>{{ order.order_number }}</td>
+              <td>{{ order.supplier.name if order.supplier else '–' }}</td>
+              <td>{{ order.expected_date or '–' }}</td>
+              <td>{{ order.status.value }}</td>
+              <td>{{ entry.outstanding_lines }}</td>
+              <td>{{ '%.1f' % entry.remaining }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <p>Aktuell liegen keine offenen Bestellungen vor.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/templates/purchase_orders/list.html
+++ b/templates/purchase_orders/list.html
@@ -1,0 +1,133 @@
+{% extends "base.html" %}
+{% block title %}Bestellungen - Lagerverwaltung{% endblock %}
+{% block content %}
+<section>
+  <h2>Offene und laufende Bestellungen</h2>
+  {% if orders %}
+    {% for order in orders %}
+    <article class="card order-card">
+      <header>
+        <h3>Bestellung {{ order.order_number }}</h3>
+        <p>
+          Lieferant: {{ order.supplier.name if order.supplier else '–' }}
+          | Status: {{ order.status.value }}
+          | Erwartet: {{ order.expected_date.strftime('%d.%m.%Y') if order.expected_date else '–' }}
+        </p>
+        {% if order.notes %}
+        <p class="muted">{{ order.notes }}</p>
+        {% endif %}
+      </header>
+      <section>
+        <h4>Positionen</h4>
+        {% if order.lines %}
+        <table>
+          <thead>
+            <tr>
+              <th>Artikel</th>
+              <th>Beschreibung</th>
+              <th>Bestellt</th>
+              <th>Geliefert</th>
+              <th>Preis</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for line in order.lines %}
+            <tr>
+              <td>{{ line.item.name if line.item else '–' }}</td>
+              <td>{{ line.description or '-' }}</td>
+              <td>{{ '%.2f'|format(line.ordered_quantity) }}</td>
+              <td>{{ '%.2f'|format(line.received_quantity) }}</td>
+              <td>{{ '%.2f'|format(line.unit_price) if line.unit_price is not none else '-' }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {% else %}
+        <p>Noch keine Positionen erfasst.</p>
+        {% endif %}
+      </section>
+      <section class="form-section">
+        <h4>Position hinzufügen</h4>
+        <form method="post" action="{{ url_for('add_purchase_order_line', order_id=order.id) }}" class="form-grid">
+          <label>Artikel
+            <select name="item_id">
+              <option value="">Freitextposition</option>
+              {% for item in items %}
+              <option value="{{ item.id }}">{{ item.sku }} – {{ item.name }}</option>
+              {% endfor %}
+            </select>
+          </label>
+          <label>Beschreibung
+            <input type="text" name="description" />
+          </label>
+          <label>Menge
+            <input type="number" name="ordered_quantity" step="0.01" required />
+          </label>
+          <label>Preis (optional)
+            <input type="number" name="unit_price" step="0.01" />
+          </label>
+          <div class="form-actions">
+            <button type="submit">Position speichern</button>
+          </div>
+        </form>
+      </section>
+      {% if order.lines %}
+      <section class="form-section">
+        <h4>Wareneingang erfassen</h4>
+        <form method="post" action="{{ url_for('receive_purchase_order', order_id=order.id) }}" class="form-grid">
+          <label>Position
+            <select name="line_id" required>
+              {% for line in order.lines %}
+              <option value="{{ line.id }}">{{ line.item.name if line.item else line.description }} (bestellt {{ '%.2f'|format(line.ordered_quantity) }})</option>
+              {% endfor %}
+            </select>
+          </label>
+          <label>Gelieferte Menge
+            <input type="number" step="0.01" name="received_quantity" required />
+          </label>
+          <div class="form-actions">
+            <button type="submit">Wareneingang speichern</button>
+          </div>
+        </form>
+      </section>
+      {% endif %}
+    </article>
+    {% endfor %}
+  {% else %}
+  <p>Keine Bestellungen vorhanden.</p>
+  {% endif %}
+</section>
+
+<section class="form-section">
+  <h2>Neue Bestellung anlegen</h2>
+  <form method="post" class="form-grid">
+    <label>Bestellnummer
+      <input type="text" name="order_number" required />
+    </label>
+    <label>Lieferant
+      <select name="supplier_id">
+        <option value="">–</option>
+        {% for supplier in suppliers %}
+        <option value="{{ supplier.id }}">{{ supplier.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Status
+      <select name="status_value">
+        {% for status_value in status_values %}
+        <option value="{{ status_value.value }}">{{ status_value.value }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>Erwartetes Lieferdatum
+      <input type="date" name="expected_date" />
+    </label>
+    <label class="full-width">Notizen
+      <textarea name="notes" rows="3"></textarea>
+    </label>
+    <div class="form-actions">
+      <button type="submit">Bestellung anlegen</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/templates/suppliers/list.html
+++ b/templates/suppliers/list.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block title %}Lieferanten - Lagerverwaltung{% endblock %}
+{% block content %}
+<section>
+  <h2>Lieferanten</h2>
+  {% if suppliers %}
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>E-Mail</th>
+        <th>Telefon</th>
+        <th>Notizen</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for supplier in suppliers %}
+      <tr>
+        <td>{{ supplier.name }}</td>
+        <td>{{ supplier.contact_email or '-' }}</td>
+        <td>{{ supplier.contact_phone or '-' }}</td>
+        <td>{{ supplier.notes or '-' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>Noch keine Lieferanten angelegt.</p>
+  {% endif %}
+</section>
+
+<section class="form-section">
+  <h2>Neuen Lieferanten anlegen</h2>
+  <form method="post" class="form-grid">
+    <label>Name
+      <input type="text" name="name" required />
+    </label>
+    <label>E-Mail
+      <input type="email" name="contact_email" />
+    </label>
+    <label>Telefon
+      <input type="text" name="contact_phone" />
+    </label>
+    <label class="full-width">Notizen
+      <textarea name="notes" rows="3"></textarea>
+    </label>
+    <div class="form-actions">
+      <button type="submit">Speichern</button>
+    </div>
+  </form>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- build a FastAPI-based warehouse management system with SQLAlchemy models, CRUD services, REST endpoints, and ERP integration
- add a Jinja2-powered HTML interface with inventory dashboards, management forms, and ERP action triggers plus styling assets
- document setup steps, configuration, and dependencies for running the application
- add a planning overview with disposition suggestions, navigation entry, and styling enhancements

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d0250730b8832c8ab27738c0d52bdb